### PR TITLE
BugFix: non array nodes not named 'master' cause old style running jobs to fail autostart

### DIFF
--- a/specs/default/chef/site-cookbooks/pbspro/files/default/autostart.py
+++ b/specs/default/chef/site-cookbooks/pbspro/files/default/autostart.py
@@ -383,10 +383,7 @@ class PBSAutostart:
         pbsnodes = self.driver.pbsnodes().get(None)
         existing_machines = []
         
-        def ignore_master(node):
-            return node["Template"] == "master"
-        
-        booting_instance_ids = autoscale_util.nodes_by_instance_id(self.clusters_api, nodearray_definitions, filter_func=ignore_master)
+        booting_instance_ids = autoscale_util.nodes_by_instance_id(self.clusters_api, nodearray_definitions)
         
         instance_ids_to_shutdown = Record()
         

--- a/specs/default/chef/site-cookbooks/pbspro/files/default/autostart_test.py
+++ b/specs/default/chef/site-cookbooks/pbspro/files/default/autostart_test.py
@@ -853,6 +853,21 @@ class Test(unittest.TestCase):
                                         'select': '2:ncpus=2:slot_type=execute'}}]
         self._test_live(queued, MachineRequest("execute", "a2", 2, "group_id", "single"))
         
+    def test_old_style_nodes(self):
+        queued = [{'job_id': '123',
+                   'job_state': 'Q',
+                   'exec_host': 'cazlrss28/0*8',
+                   'exec_vnode': '(cazlrss28:ncpus=8)',
+                   'resource_list': {
+                       'mpiprocs': '8',
+                       'ncpus': '8',
+                       'nodect': '1',
+                       'nodes': '1:ppn8',
+                       'place': 'scatter',
+                       'select': '1:ncpus=8:mpiprocs=8',
+                       'ungrouped': 'true'}}]
+        self._test_live(queued, MachineRequest("execute", "a2", 1, "", ""))
+        
     def test_forced_assignment(self):
         queued = [{'job_id': '1',
                       'job_state': 'Q',

--- a/specs/default/chef/site-cookbooks/pbspro/files/default/mockpbs.py
+++ b/specs/default/chef/site-cookbooks/pbspro/files/default/mockpbs.py
@@ -117,12 +117,5 @@ def mock_job(raw_job):
     if job["array"]:
         job["array_state_count"] = raw_job.pop("array_state_count")
     
-    if "nodes" in job.Resource_List:
-        if "ppn" in raw_job and "ncpus" not in raw_job:
-            raw_job["resource_list"]["ncpus"] = raw_job["ppn"]
-        job["resource_list"]["nodect"] = int(raw_job.pop("nodes"))
-        job["resource_list"]["place"] = "scatter"
-        job["resource_list"]["select"] = "{n}:ncpus={n}:mpiprocs={n}".format(n=job["resource_list"]["nodect"])
-    
     # remaining things are assumed to be resources
     return job


### PR DESCRIPTION
This is a hotfix imported from the CycleCloud repo (see PR 1453544)