### PR TITLE
support qsub -W depend=afterok:0 from non-master node

### DIFF
--- a/specs/default/chef/site-cookbooks/pbspro/files/default/doqmgr.sh
+++ b/specs/default/chef/site-cookbooks/pbspro/files/default/doqmgr.sh
@@ -7,6 +7,7 @@ set -e
 /opt/pbs/bin/qmgr -c 'set server managers = root@*'
 /opt/pbs/bin/qmgr -c 'set server query_other_jobs = true'
 /opt/pbs/bin/qmgr -c 'set server scheduler_iteration = 15'
+/opt/pbs/bin/qmgr -c 'set server flatuid = true'
 
 function create_resource() {
 	/opt/pbs/bin/qmgr -c "list resource $1" >/dev/null  2>/dev/null   || \

--- a/specs/default/chef/site-cookbooks/pbspro/recipes/execute.rb
+++ b/specs/default/chef/site-cookbooks/pbspro/recipes/execute.rb
@@ -28,7 +28,7 @@ if node[:autoscale] then
     custom_resources = node[:autoscale].to_h
 end
 
-schedint = cluster.scheduler
+schedint = cluster.scheduler.split(".").first
 slots = node[:pbspro][:slots] || nil
 
 if schedint != nil


### PR DESCRIPTION
Makes it possible to reference job number in a dependency. 
Makes it possible to submit job with dependency from non-master node.