### PR TITLE
default ncpus to vcpu_count

### DIFF
--- a/generate_autoscale_json.sh
+++ b/generate_autoscale_json.sh
@@ -89,7 +89,7 @@ temp_autoscale=$TEMP/autoscale.json.$(date +%s)
                 --lock-file    $INSTALLDIR/scalelib.lock \
                 --log-config   $INSTALLDIR/logging.conf \
                 --disable-default-resources \
-                --default-resource '{"select": {}, "name": "ncpus", "value": "node.pcpu_count"}' \
+                --default-resource '{"select": {}, "name": "ncpus", "value": "node.vcpu_count"}' \
                 --default-resource '{"select": {}, "name": "ngpus", "value": "node.gpu_count"}' \
                 --default-resource '{"select": {}, "name": "disk", "value": "size::20g"}' \
                 --default-resource '{"select": {}, "name": "host", "value": "node.hostname"}' \


### PR DESCRIPTION
this supports scheduling to all vcpus on HT VMs and does not impact non-HT VMs