### PR TITLE
Feature/2.0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ in CycleCloud by specifying the PBSPro OSS version.
 
 Note: When using the cluster that is shipped with CycleCloud, the autoscaler and default queues are already installed.
 
-First, download the installer pkg from GitHub. For example, you can download the [2.0.11 release here](https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.11/cyclecloud-pbspro-pkg-2.0.11.tar.gz)
+First, download the installer pkg from GitHub. For example, you can download the [2.0.12 release here](https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.12/cyclecloud-pbspro-pkg-2.0.12.tar.gz)
 
 ```bash
 # Prerequisite: python3, 3.6 or newer, must be installed and in the PATH
-wget https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.11/cyclecloud-pbspro-pkg-2.0.11.tar.gz
-tar xzf cyclecloud-pbspro-pkg-2.0.11.tar.gz
+wget https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.12/cyclecloud-pbspro-pkg-2.0.12.tar.gz
+tar xzf cyclecloud-pbspro-pkg-2.0.12.tar.gz
 cd cyclecloud-pbspro
 # Optional, but recommended. Adds relevant resources and enables strict placement
 ./initialize_pbs.sh

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ in CycleCloud by specifying the PBSPro OSS version.
 
 Note: When using the cluster that is shipped with CycleCloud, the autoscaler and default queues are already installed.
 
-First, download the installer pkg from GitHub. For example, you can download the [2.0.12 release here](https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.12/cyclecloud-pbspro-pkg-2.0.12.tar.gz)
+First, download the installer pkg from GitHub. For example, you can download the [2.0.13 release here](https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.13/cyclecloud-pbspro-pkg-2.0.13.tar.gz)
 
 ```bash
 # Prerequisite: python3, 3.6 or newer, must be installed and in the PATH
-wget https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.12/cyclecloud-pbspro-pkg-2.0.12.tar.gz
-tar xzf cyclecloud-pbspro-pkg-2.0.12.tar.gz
+wget https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.13/cyclecloud-pbspro-pkg-2.0.13.tar.gz
+tar xzf cyclecloud-pbspro-pkg-2.0.13.tar.gz
 cd cyclecloud-pbspro
 # Optional, but recommended. Adds relevant resources and enables strict placement
 ./initialize_pbs.sh

--- a/README.md
+++ b/README.md
@@ -273,7 +273,15 @@ execute Standard_F2s_v2 50
 execute Standard_D2_v4 50
 execute Standard_E2s_v4 50
 ```
-
+## Timeouts
+By default we set idle and boot timeouts across all nodes.
+```"idle_timeout": 300,
+   "boot_timeout": 3600
+```
+You can also set these per nodearray.
+```"idle_timeout": {"default": 300, "nodearray1": 600, "nodearray2": 900},
+   "boot_timeout": {"default": 3600, "nodearray1": 7200, "nodearray2": 900},
+```
 ## Logging
 By default, `azpbs` will use `/opt/cycle/pbspro/logging.conf`, as defined in `/opt/cycle/pbsspro/autoscale.json`. This will create the following logs.
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ in CycleCloud by specifying the PBSPro OSS version.
 
 Note: When using the cluster that is shipped with CycleCloud, the autoscaler and default queues are already installed.
 
-First, download the installer pkg from GitHub. For example, you can download the [2.0.13 release here](https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.13/cyclecloud-pbspro-pkg-2.0.13.tar.gz)
+First, download the installer pkg from GitHub. For example, you can download the [2.0.14 release here](https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.14/cyclecloud-pbspro-pkg-2.0.14.tar.gz)
 
 ```bash
 # Prerequisite: python3, 3.6 or newer, must be installed and in the PATH
-wget https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.13/cyclecloud-pbspro-pkg-2.0.13.tar.gz
-tar xzf cyclecloud-pbspro-pkg-2.0.13.tar.gz
+wget https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.14/cyclecloud-pbspro-pkg-2.0.14.tar.gz
+tar xzf cyclecloud-pbspro-pkg-2.0.14.tar.gz
 cd cyclecloud-pbspro
 # Optional, but recommended. Adds relevant resources and enables strict placement
 ./initialize_pbs.sh

--- a/package.py
+++ b/package.py
@@ -10,7 +10,7 @@ from argparse import Namespace
 from subprocess import check_call
 from typing import Dict, List, Optional
 
-SCALELIB_VERSION = "0.2.8"
+SCALELIB_VERSION = "0.2.9"
 CYCLECLOUD_API_VERSION = "8.1.0"
 
 

--- a/package.py
+++ b/package.py
@@ -10,7 +10,7 @@ from argparse import Namespace
 from subprocess import check_call
 from typing import Dict, List, Optional
 
-SCALELIB_VERSION = "0.2.7"
+SCALELIB_VERSION = "0.2.8"
 CYCLECLOUD_API_VERSION = "8.1.0"
 
 

--- a/pbspro/setup.py
+++ b/pbspro/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 from setuptools.command.test import Command
 from setuptools.command.test import test as TestCommand  # noqa: N812
 
-__version__ = "2.0.11"
+__version__ = "2.0.12"
 CWD = os.path.dirname(os.path.abspath(__file__))
 
 

--- a/pbspro/setup.py
+++ b/pbspro/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 from setuptools.command.test import Command
 from setuptools.command.test import test as TestCommand  # noqa: N812
 
-__version__ = "2.0.12"
+__version__ = "2.0.13"
 CWD = os.path.dirname(os.path.abspath(__file__))
 
 

--- a/pbspro/setup.py
+++ b/pbspro/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 from setuptools.command.test import Command
 from setuptools.command.test import test as TestCommand  # noqa: N812
 
-__version__ = "2.0.13"
+__version__ = "2.0.14"
 CWD = os.path.dirname(os.path.abspath(__file__))
 
 

--- a/pbspro/setup.py
+++ b/pbspro/setup.py
@@ -127,7 +127,7 @@ setup(
             "../notices",
         ]
     },
-    install_requires=["typing_extensions", "certifi==2020.12.5", "zipp==3.6"],
+    install_requires=["typing_extensions==3.7.4.3", "certifi==2020.12.5", "zipp==3.6"],
     tests_require=["pytest==3.2.3"],
     cmdclass={"test": PyTest, "format": Formatter, "types": TypeChecking},
     url="http://www.cyclecomputing.com",

--- a/pbspro/src/pbspro/autoscaler.py
+++ b/pbspro/src/pbspro/autoscaler.py
@@ -10,7 +10,7 @@ from hpc.autoscale.job import demandprinter
 from hpc.autoscale.job.demand import DemandResult
 from hpc.autoscale.job.demandcalculator import DemandCalculator
 from hpc.autoscale.node.nodehistory import NodeHistory
-from hpc.autoscale.node.nodemanager import new_node_manager
+from hpc.autoscale.node.nodemanager import NodeManager, new_node_manager
 from hpc.autoscale.results import DefaultContextHandler, register_result_handler
 from hpc.autoscale.util import SingletonLock, json_load
 
@@ -152,6 +152,7 @@ def new_demand_calculator(
     ctx_handler: Optional[DefaultContextHandler] = None,
     node_history: Optional[NodeHistory] = None,
     singleton_lock: Optional[SingletonLock] = None,
+    node_mgr: Optional[NodeManager] = None,
 ) -> DemandCalculator:
     if pbs_driver is None:
         pbs_driver = PBSProDriver(config)
@@ -163,7 +164,9 @@ def new_demand_calculator(
         node_history = pbs_driver.new_node_history(config)
 
     # keep it as a config
-    node_mgr = new_node_manager(config, existing_nodes=pbs_env.scheduler_nodes)
+    node_mgr = node_mgr or new_node_manager(
+        config, existing_nodes=pbs_env.scheduler_nodes
+    )
     pbs_driver.preprocess_node_mgr(config, node_mgr)
     singleton_lock = singleton_lock or pbs_driver.new_singleton_lock(config)
     assert singleton_lock

--- a/pbspro/src/pbspro/autoscaler.py
+++ b/pbspro/src/pbspro/autoscaler.py
@@ -107,7 +107,11 @@ def autoscale_pbspro(
         timed_out_to_deleted = pbs_driver.handle_boot_timeout(timed_out_booting) or []
 
     if unmatched_for_5_mins:
-        logging.info("unmatched_for_5_mins %s", unmatched_for_5_mins)
+        logging.info(
+            "The following nodes have reached the idle_timeout (%s): %s",
+            idle_timeout,
+            unmatched_for_5_mins,
+        )
         unmatched_nodes_to_delete = (
             pbs_driver.handle_draining(unmatched_for_5_mins) or []
         )
@@ -246,10 +250,7 @@ def print_demand(
     output_format = output_format or "table"
 
     demandprinter.print_demand(
-        output_columns,
-        demand_result,
-        output_format=output_format,
-        log=log,
+        output_columns, demand_result, output_format=output_format, log=log,
     )
     return demand_result
 

--- a/pbspro/src/pbspro/autoscaler.py
+++ b/pbspro/src/pbspro/autoscaler.py
@@ -105,6 +105,8 @@ def autoscale_pbspro(
             "The following nodes have timed out while booting: %s", timed_out_booting
         )
         timed_out_to_deleted = pbs_driver.handle_boot_timeout(timed_out_booting) or []
+        for node in timed_out_booting:
+            node.closed = True
 
     if unmatched_for_5_mins:
         logging.info(

--- a/pbspro/src/pbspro/driver.py
+++ b/pbspro/src/pbspro/driver.py
@@ -314,6 +314,14 @@ class PBSProDriver(SchedulerDriver):
         return nodes
 
     def handle_boot_timeout(self, nodes: List[Node]) -> List[Node]:
+        for node in nodes:
+            if node.hostname:
+                try:
+                    self.pbscmd.pbsnodes(
+                        "-o", node.hostname, "-C", "cyclecloud offline"
+                    )
+                except CalledProcessError:
+                    continue
         return nodes
 
     def handle_draining(self, nodes: List[Node]) -> List[Node]:

--- a/pbspro/src/pbspro/driver.py
+++ b/pbspro/src/pbspro/driver.py
@@ -109,6 +109,9 @@ class PBSProDriver(SchedulerDriver):
 
         for node in nodes:
 
+            if node.keep_alive:
+                continue
+
             if node.state == "Failed":
                 node.closed = True
                 to_delete.append(node)
@@ -812,9 +815,9 @@ def parse_scheduler_node(
         state = "partially-free"
 
     node.metadata["pbs_state"] = state
-
-    if "down" in state:
-        node.marked_for_deletion = True
+    # This ends up ignoring KeepAlive, so just let downstream handling of down/offline nodes.
+    # if "down" in state:
+    #     node.marked_for_deletion = True
 
     node.metadata["last_state_change_time"] = ndict.get("last_state_change_time", "")
 

--- a/pbspro/src/pbspro/driver.py
+++ b/pbspro/src/pbspro/driver.py
@@ -122,7 +122,13 @@ class PBSProDriver(SchedulerDriver):
 
             job_state = node.metadata.get("pbs_state", "")
             if "down" in job_state:
+
                 node.closed = True
+                if "state-unknown" in job_state:
+                    logging.warning(
+                        "Node is in state-unknown - skipping scale down - %s", node
+                    )
+                    continue
                 # no private_ip == no dns entry, so we can safely remove it
                 if "offline" in job_state or not node.private_ip:
                     to_delete.append(node)
@@ -135,7 +141,7 @@ class PBSProDriver(SchedulerDriver):
             self.handle_draining(to_drain)
 
         if to_delete:
-            logging.info("Deleting down,offline nodes: %s", to_drain)
+            logging.info("Deleting down,offline nodes: %s", to_delete)
             return self.handle_post_delete(to_delete)
         return []
 
@@ -214,9 +220,21 @@ class PBSProDriver(SchedulerDriver):
                 try:
                     ndicts = self.pbscmd.qmgr_parsed("list", "node", node.hostname)
                     if ndicts and ndicts[0].get("resources_available.ccnodeid"):
-                        logging.info(
-                            "ccnodeid is already defined on %s. Skipping", node
-                        )
+                        comment = ndicts[0].get("comment", "")
+                        if "offline" in ndicts[0].get("state", "") and (
+                            comment.startswith("cyclecloud offline")
+                            or comment.startswith("cyclecloud joined")
+                        ):
+                            logging.info(
+                                "%s is offline. Setting it back to online", node
+                            )
+                            self.pbscmd.pbsnodes(
+                                "-r", node.hostname, "-C", "cyclecloud restored"
+                            )
+                        else:
+                            logging.info(
+                                "ccnodeid is already defined on %s. Skipping", node
+                            )
                         continue
                     # TODO RDH should we just delete it instead?
                     logging.info(
@@ -281,7 +299,7 @@ class PBSProDriver(SchedulerDriver):
                         "ccnodeid", node.resources["ccnodeid"]
                     ),
                 )
-                self.pbscmd.pbsnodes("-r", node.hostname)
+                self.pbscmd.pbsnodes("-r", node.hostname, "-C", "cyclecloud joined")
                 ret.append(node)
             except SubprocessError as e:
                 logging.error(
@@ -327,7 +345,9 @@ class PBSProDriver(SchedulerDriver):
                     ret.append(node)
             else:
                 try:
-                    self.pbscmd.pbsnodes("-o", node.hostname)
+                    self.pbscmd.pbsnodes(
+                        "-o", node.hostname, "-C", "cyclecloud offline"
+                    )
 
                     # # Due to a delay in when pbsnodes -o exits to when pbsnodes -a
                     # # actually reports an offline state, w ewill just optimistically set it to offline
@@ -812,5 +832,7 @@ def parse_scheduler_node(
 
     if "exclusive" in node.metadata["pbs_state"]:
         node.closed = True
+
+    node.metadata["comment"] = ndict.get("comment", "")
 
     return node

--- a/pbspro/src/pbspro/parser.py
+++ b/pbspro/src/pbspro/parser.py
@@ -27,10 +27,7 @@ class PBSProParser:
     def resource_definitions(self) -> Dict[str, "PBSProResourceDefinition"]:
         return self.__resource_definitions
 
-    def convert_resource_list(
-        self,
-        raw_dict: Dict[str, Any],
-    ) -> Dict[str, Any]:
+    def convert_resource_list(self, raw_dict: Dict[str, Any],) -> Dict[str, Any]:
         """
         secondary parsing of Resource_List dictionary. Mostly this will convert
         resources to their appropriate type, as per PBSProResourceDefinition.parse
@@ -166,11 +163,15 @@ class PBSProParser:
                 assigned_value = res_assigned.get(res_name) or 0
                 res_def = self.resource_definitions.get(res_name)
                 if not res_def:
-                    logging.error(f"Unknown resource {res_name}. Will not be used for autoscale")
+                    logging.error(
+                        f"Unknown resource {res_name}. Will not be used for autoscale"
+                    )
                     continue
                 initial_value = res_def.type.parse(initial_value)
-                assigned_value = res_def.type.parse(assigned_value)
-                current_value = initial_value  - assigned_value
+                # type checking gets confused here, but by the time we are doing the `-`
+                # they will definitely be numeric
+                assigned_value = res_def.type.parse(assigned_value)  # type: ignore
+                current_value = initial_value - assigned_value  # type: ignore
 
                 if res_name not in shared_resources:
                     shared_resources[res_name] = []

--- a/pbspro/src/pbspro/pbsqueue.py
+++ b/pbspro/src/pbspro/pbsqueue.py
@@ -110,9 +110,11 @@ class PBSProQueue:
 
             if resource.is_host:
                 continue
-            
+
             if rname not in self.resource_state.shared_resources:
-                raise RuntimeError(f"Undefined resource {rname}. Is this a misconfigured server_dyn_res?")
+                raise RuntimeError(
+                    f"Undefined resource {rname}. Is this a misconfigured server_dyn_res?"
+                )
 
             shared_resource_list: List[
                 conslib.SharedResource
@@ -182,7 +184,7 @@ def read_queues(
         state_count = parser.parse_state_counts(qdict["state_count"])
 
         resource_state = parser.parse_resource_state(qdict, scheduler_shared_resources)
-        
+
         queue = PBSProQueue(
             name=qdict["name"],
             queue_type=qdict["queue_type"],
@@ -194,7 +196,8 @@ def read_queues(
             resources_default=parser.parse_resources_default(qdict),
             default_chunk=parser.parse_default_chunk(qdict),
             resource_definitions=resource_definitions,
-            enabled=qdict["enabled"].lower() == "true" and qdict["name"] not in ignore_queues,
+            enabled=qdict["enabled"].lower() == "true"
+            and qdict["name"] not in ignore_queues,
             started=qdict["started"].lower() == "true",
         )
         ret[queue.name] = queue

--- a/pbspro/src/pbspro/scheduler.py
+++ b/pbspro/src/pbspro/scheduler.py
@@ -13,9 +13,7 @@ from pbspro.resource import BooleanType, PBSProResourceDefinition, ResourceState
 
 class PBSProScheduler:
     def __init__(
-        self,
-        sched_dict: Dict[str, str],
-        resource_state: ResourceState,
+        self, sched_dict: Dict[str, str], resource_state: ResourceState,
     ) -> None:
         btype = BooleanType()
         self.do_not_span_psets = btype.parse(
@@ -33,8 +31,8 @@ class PBSProScheduler:
         self.sched_log = sched_dict["sched_log"]
         self.sched_priv = sched_dict["sched_priv"]
         priv_config_path = os.path.join(self.sched_priv, "sched_config")
-        self.resources_for_scheduling = (
-            get_pbspro_parser().parse_resources_from_sched_priv(priv_config_path)
+        self.resources_for_scheduling = get_pbspro_parser().parse_resources_from_sched_priv(
+            priv_config_path
         )
         self.state = sched_dict["state"]
         self.hostname = sched_dict["sched_host"].split(".")[0]
@@ -67,10 +65,7 @@ class PBSProScheduler:
         return self.sched_dict["name"] == "default"
 
     def __repr__(self) -> str:
-        return "Scheduler(hostname={}, state={})".format(
-            self.hostname,
-            self.state,
-        )
+        return "Scheduler(hostname={}, state={})".format(self.hostname, self.state,)
 
 
 def read_schedulers(

--- a/pbspro/test/pbspro_test/driver_test.py
+++ b/pbspro/test/pbspro_test/driver_test.py
@@ -104,7 +104,7 @@ def test_down_long_enough() -> None:
     now = datetime.datetime.now()
 
     # False: missing last_state_change_time
-    driver = PBSProDriver(down_timeout=300)
+    driver = PBSProDriver({}, down_timeout=300)
     assert not driver._down_long_enough(now, node)
 
     # False: last_state_change_time < 300 seconds ago

--- a/project.ini
+++ b/project.ini
@@ -2,11 +2,11 @@
 name = pbspro
 label = OpenPBS
 type = scheduler
-version = 2.0.11
+version = 2.0.12
 autoupgrade = true
 
 [blobs]
-Files = cyclecloud-pbspro-pkg-2.0.11.tar.gz, hwloc-libs-1.11.9-3.el8.x86_64.rpm, pbspro-execution-18.1.4-0.x86_64.rpm, pbspro-server-18.1.4-0.x86_64.rpm, pbspro-client-18.1.4-0.x86_64.rpm, openpbs-client-20.0.1-0.x86_64.rpm, openpbs-server-20.0.1-0.x86_64.rpm, openpbs-execution-20.0.1-0.x86_64.rpm
+Files = cyclecloud-pbspro-pkg-2.0.12.tar.gz, hwloc-libs-1.11.9-3.el8.x86_64.rpm, pbspro-execution-18.1.4-0.x86_64.rpm, pbspro-server-18.1.4-0.x86_64.rpm, pbspro-client-18.1.4-0.x86_64.rpm, openpbs-client-20.0.1-0.x86_64.rpm, openpbs-server-20.0.1-0.x86_64.rpm, openpbs-execution-20.0.1-0.x86_64.rpm
 
 [spec server]
 run_list = role[pbspro_server_role]

--- a/project.ini
+++ b/project.ini
@@ -2,11 +2,11 @@
 name = pbspro
 label = OpenPBS
 type = scheduler
-version = 2.0.13
+version = 2.0.14
 autoupgrade = true
 
 [blobs]
-Files = cyclecloud-pbspro-pkg-2.0.13.tar.gz, hwloc-libs-1.11.9-3.el8.x86_64.rpm, pbspro-execution-18.1.4-0.x86_64.rpm, pbspro-server-18.1.4-0.x86_64.rpm, pbspro-client-18.1.4-0.x86_64.rpm, openpbs-client-20.0.1-0.x86_64.rpm, openpbs-server-20.0.1-0.x86_64.rpm, openpbs-execution-20.0.1-0.x86_64.rpm
+Files = cyclecloud-pbspro-pkg-2.0.14.tar.gz, hwloc-libs-1.11.9-3.el8.x86_64.rpm, pbspro-execution-18.1.4-0.x86_64.rpm, pbspro-server-18.1.4-0.x86_64.rpm, pbspro-client-18.1.4-0.x86_64.rpm, openpbs-client-20.0.1-0.x86_64.rpm, openpbs-server-20.0.1-0.x86_64.rpm, openpbs-execution-20.0.1-0.x86_64.rpm
 
 [spec server]
 run_list = role[pbspro_server_role]

--- a/project.ini
+++ b/project.ini
@@ -2,11 +2,11 @@
 name = pbspro
 label = OpenPBS
 type = scheduler
-version = 2.0.12
+version = 2.0.13
 autoupgrade = true
 
 [blobs]
-Files = cyclecloud-pbspro-pkg-2.0.12.tar.gz, hwloc-libs-1.11.9-3.el8.x86_64.rpm, pbspro-execution-18.1.4-0.x86_64.rpm, pbspro-server-18.1.4-0.x86_64.rpm, pbspro-client-18.1.4-0.x86_64.rpm, openpbs-client-20.0.1-0.x86_64.rpm, openpbs-server-20.0.1-0.x86_64.rpm, openpbs-execution-20.0.1-0.x86_64.rpm
+Files = cyclecloud-pbspro-pkg-2.0.13.tar.gz, hwloc-libs-1.11.9-3.el8.x86_64.rpm, pbspro-execution-18.1.4-0.x86_64.rpm, pbspro-server-18.1.4-0.x86_64.rpm, pbspro-client-18.1.4-0.x86_64.rpm, openpbs-client-20.0.1-0.x86_64.rpm, openpbs-server-20.0.1-0.x86_64.rpm, openpbs-execution-20.0.1-0.x86_64.rpm
 
 [spec server]
 run_list = role[pbspro_server_role]

--- a/specs/default/chef/site-cookbooks/pbspro/attributes/default.rb
+++ b/specs/default/chef/site-cookbooks/pbspro/attributes/default.rb
@@ -3,7 +3,7 @@
 #
 # 
 
-default[:pbspro][:autoscale_version] = "2.0.13"
+default[:pbspro][:autoscale_version] = "2.0.14"
 default[:pbspro][:autoscale_installer] = "cyclecloud-pbspro-pkg-#{node[:pbspro][:autoscale_version]}.tar.gz"
 default[:pbspro][:version] = "20.0.1-0"
 default[:pbspro][:slots] = nil

--- a/specs/default/chef/site-cookbooks/pbspro/attributes/default.rb
+++ b/specs/default/chef/site-cookbooks/pbspro/attributes/default.rb
@@ -3,7 +3,7 @@
 #
 # 
 
-default[:pbspro][:autoscale_version] = "2.0.11"
+default[:pbspro][:autoscale_version] = "2.0.12"
 default[:pbspro][:autoscale_installer] = "cyclecloud-pbspro-pkg-#{node[:pbspro][:autoscale_version]}.tar.gz"
 default[:pbspro][:version] = "20.0.1-0"
 default[:pbspro][:slots] = nil

--- a/specs/default/chef/site-cookbooks/pbspro/attributes/default.rb
+++ b/specs/default/chef/site-cookbooks/pbspro/attributes/default.rb
@@ -3,7 +3,7 @@
 #
 # 
 
-default[:pbspro][:autoscale_version] = "2.0.12"
+default[:pbspro][:autoscale_version] = "2.0.13"
 default[:pbspro][:autoscale_installer] = "cyclecloud-pbspro-pkg-#{node[:pbspro][:autoscale_version]}.tar.gz"
 default[:pbspro][:version] = "20.0.1-0"
 default[:pbspro][:slots] = nil

--- a/specs/default/chef/site-cookbooks/pbspro/metadata.rb
+++ b/specs/default/chef/site-cookbooks/pbspro/metadata.rb
@@ -6,7 +6,7 @@ maintainer       "Microsoft Corporation"
 license          "MIT"
 description      "Installs/Configures Open PBS Pro"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.12"
+version          "2.0.13"
 depends          "tandem"
 %w{ cganglia cshared cuser cyclecloud }.each {|c| depends c}
 

--- a/specs/default/chef/site-cookbooks/pbspro/metadata.rb
+++ b/specs/default/chef/site-cookbooks/pbspro/metadata.rb
@@ -6,7 +6,7 @@ maintainer       "Microsoft Corporation"
 license          "MIT"
 description      "Installs/Configures Open PBS Pro"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.11"
+version          "2.0.12"
 depends          "tandem"
 %w{ cganglia cshared cuser cyclecloud }.each {|c| depends c}
 

--- a/specs/default/chef/site-cookbooks/pbspro/metadata.rb
+++ b/specs/default/chef/site-cookbooks/pbspro/metadata.rb
@@ -6,7 +6,7 @@ maintainer       "Microsoft Corporation"
 license          "MIT"
 description      "Installs/Configures Open PBS Pro"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.13"
+version          "2.0.14"
 depends          "tandem"
 %w{ cganglia cshared cuser cyclecloud }.each {|c| depends c}
 

--- a/specs/default/chef/site-cookbooks/pbspro/recipes/execute.rb
+++ b/specs/default/chef/site-cookbooks/pbspro/recipes/execute.rb
@@ -81,7 +81,7 @@ end
 node_created_guard = "#{node['cyclecloud']['chefstate']}/pbs.nodecreated"
 
 bash "await-joining-cluster" do
-  code lazy { "/opt/pbs/bin/pbsnodes -o #{node[:hostname]}"}
+  code lazy { "/opt/pbs/bin/pbsnodes -o #{node[:hostname]} -C 'cyclecloud offline'"}
   only_if do 
     lazy {
       cmd = Mixlib::ShellOut.new('/opt/pbs/bin/pbsnodes -a')

--- a/specs/default/chef/site-cookbooks/pbspro/recipes/execute.rb
+++ b/specs/default/chef/site-cookbooks/pbspro/recipes/execute.rb
@@ -8,11 +8,14 @@ pbsprover = node[:pbspro][:version]
 
 plat_ver = node['platform_version'].to_i
 pbsdist = "el#{plat_ver}"
+package_name = node[:pbspro][:package]
 
-if pbsprover.to_i < 20 
-  package_name = "pbspro-execution-#{pbsprover}.x86_64.rpm"
-else
-  package_name = "openpbs-execution-#{pbsprover}.x86_64.rpm"
+if package_name == nil
+  if pbsprover.to_i < 20 
+    package_name = "pbspro-execution-#{pbsprover}.x86_64.rpm"
+  else
+    package_name = "openpbs-execution-#{pbsprover}.x86_64.rpm"
+  end
 end
 
 jetpack_download package_name do

--- a/templates/openpbs.txt
+++ b/templates/openpbs.txt
@@ -215,8 +215,8 @@ Order = 15
         HideLabel = true
         Config.Plugin = pico.widget.HtmlTemplateWidget
         Config.Template = ''' <p>The directory <code>/sched</code> is a network attached mount and exists in all nodes of the cluster. 
-            GridEngine Root directory resides in this share. It's managed by the scheduler node. 
-            To disable the mount of the GridEngine directory, and to supply your own for a <strong>hybrid scenario</strong>, select the checkbox below '''
+            It's managed by the scheduler node. 
+            To disable the mount of the /sched directory, and to supply your own for a <strong>hybrid scenario</strong>, select the checkbox below '''
         Order = 6
 
         [[[parameter NFSSchedDisable]]]


### PR DESCRIPTION
Uses new ScaleLib - including azpbs remove_nodes --permanent (and azpbs join_nodes --include-permanent) to safely remove a node without concern it will be added once again.
Allow hostname changes after the node has joined - we safely remove it then add a new record for the new hostname
Added azpbs online/offline
Avoids race condition where a node could reuse a stale definition of the previous hostname.