### PR TITLE
Fix create_nodes via new scalelib

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ in CycleCloud by specifying the PBSPro OSS version.
 
 Note: When using the cluster that is shipped with CycleCloud, the autoscaler and default queues are already installed.
 
-First, download the installer pkg from GitHub. For example, you can download the [2.0.23 release here](https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.23/cyclecloud-pbspro-pkg-2.0.23.tar.gz)
+First, download the installer pkg from GitHub. For example, you can download the [2.0.24 release here](https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.24/cyclecloud-pbspro-pkg-2.0.24.tar.gz)
 
 ```bash
 # Prerequisite: python3, 3.6 or newer, must be installed and in the PATH
-wget https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.23/cyclecloud-pbspro-pkg-2.0.23.tar.gz
-tar xzf cyclecloud-pbspro-pkg-2.0.23.tar.gz
+wget https://github.com/Azure/cyclecloud-pbspro/releases/download/2.0.24/cyclecloud-pbspro-pkg-2.0.24.tar.gz
+tar xzf cyclecloud-pbspro-pkg-2.0.24.tar.gz
 cd cyclecloud-pbspro
 # Optional, but recommended. Adds relevant resources and enables strict placement
 ./initialize_pbs.sh

--- a/package.py
+++ b/package.py
@@ -10,7 +10,7 @@ from argparse import Namespace
 from subprocess import check_call
 from typing import Dict, List, Optional
 
-SCALELIB_VERSION = "1.0.4"
+SCALELIB_VERSION = "1.0.5"
 CYCLECLOUD_API_VERSION = "8.3.1"
 
 

--- a/pbspro/setup.py
+++ b/pbspro/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 from setuptools.command.test import Command
 from setuptools.command.test import test as TestCommand  # noqa: N812
 
-__version__ = "2.0.23"
+__version__ = "2.0.24"
 CWD = os.path.dirname(os.path.abspath(__file__))
 
 

--- a/project.ini
+++ b/project.ini
@@ -2,11 +2,11 @@
 name = pbspro
 label = OpenPBS
 type = scheduler
-version = 2.0.23
+version = 2.0.24
 autoupgrade = true
 
 [blobs]
-Files = cyclecloud-pbspro-pkg-2.0.23.tar.gz, cyclecloud_api-8.3.1-py2.py3-none-any.whl, hwloc-libs-1.11.9-3.el8.x86_64.rpm, openpbs-client-20.0.1-0.x86_64.rpm, openpbs-client-22.05.11-0.x86_64.rpm, openpbs-execution-20.0.1-0.x86_64.rpm, openpbs-execution-22.05.11-0.x86_64.rpm, openpbs-server-20.0.1-0.x86_64.rpm, openpbs-server-22.05.11-0.x86_64.rpm, pbspro-client-18.1.4-0.x86_64.rpm, pbspro-debuginfo-18.1.4-0.x86_64.rpm, pbspro-execution-18.1.4-0.x86_64.rpm, pbspro-server-18.1.4-0.x86_64.rpm
+Files = cyclecloud-pbspro-pkg-2.0.24.tar.gz, cyclecloud_api-8.3.1-py2.py3-none-any.whl, hwloc-libs-1.11.9-3.el8.x86_64.rpm, openpbs-client-20.0.1-0.x86_64.rpm, openpbs-client-22.05.11-0.x86_64.rpm, openpbs-execution-20.0.1-0.x86_64.rpm, openpbs-execution-22.05.11-0.x86_64.rpm, openpbs-server-20.0.1-0.x86_64.rpm, openpbs-server-22.05.11-0.x86_64.rpm, pbspro-client-18.1.4-0.x86_64.rpm, pbspro-debuginfo-18.1.4-0.x86_64.rpm, pbspro-execution-18.1.4-0.x86_64.rpm, pbspro-server-18.1.4-0.x86_64.rpm
 
 [spec server]
 run_list = role[pbspro_server_role]

--- a/specs/default/chef/site-cookbooks/pbspro/attributes/default.rb
+++ b/specs/default/chef/site-cookbooks/pbspro/attributes/default.rb
@@ -3,7 +3,7 @@
 #
 # 
 
-default[:pbspro][:autoscale_version] = "2.0.23"
+default[:pbspro][:autoscale_version] = "2.0.24"
 default[:pbspro][:autoscale_installer] = "cyclecloud-pbspro-pkg-#{node[:pbspro][:autoscale_version]}.tar.gz"
 default[:pbspro][:cron_method] = "pbs_cron"
 default[:pbspro][:version] = "20.0.1-0"

--- a/specs/default/chef/site-cookbooks/pbspro/metadata.rb
+++ b/specs/default/chef/site-cookbooks/pbspro/metadata.rb
@@ -6,7 +6,7 @@ maintainer       "Microsoft Corporation"
 license          "MIT"
 description      "Installs/Configures Open PBS Pro"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.23"
+version          "2.0.24"
 depends          "tandem"
 %w{ cganglia cshared cuser cyclecloud }.each {|c| depends c}
 


### PR DESCRIPTION
azpbs create_nodes was reported as failing with a json parsing error. The issue was actually in scalelib, and this fix was put into the new 1.0.5 version of scalelib.