### PR TITLE
Testing a pbs cluster

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,22 +24,6 @@ jobs:
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-      - name: Get PBS binaries
-        id: get-pbs-binaries
-        run:
-          mkdir rpms/;
-          curl -L -k -o rpms/cyclecloud_api-8.3.1-py2.py3-none-any.whl https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//cyclecloud_api-8.3.1-py2.py3-none-any.whl;
-          curl -L -k -o rpms/hwloc-libs-1.11.9-3.el8.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//hwloc-libs-1.11.9-3.el8.x86_64.rpm;
-          curl -L -k -o rpms/openpbs-client-20.0.1-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-client-20.0.1-0.x86_64.rpm;
-          curl -L -k -o rpms/openpbs-client-22.05.11-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-client-22.05.11-0.x86_64.rpm;
-          curl -L -k -o rpms/openpbs-execution-20.0.1-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-execution-20.0.1-0.x86_64.rpm;
-          curl -L -k -o rpms/openpbs-execution-22.05.11-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-execution-22.05.11-0.x86_64.rpm;
-          curl -L -k -o rpms/openpbs-server-20.0.1-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-server-20.0.1-0.x86_64.rpm;
-          curl -L -k -o rpms/openpbs-server-22.05.11-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-server-22.05.11-0.x86_64.rpm;
-          curl -L -k -o rpms/pbspro-client-18.1.4-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//pbspro-client-18.1.4-0.x86_64.rpm;
-          curl -L -k -o rpms/pbspro-debuginfo-18.1.4-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//pbspro-debuginfo-18.1.4-0.x86_64.rpm;
-          curl -L -k -o rpms/pbspro-execution-18.1.4-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//pbspro-execution-18.1.4-0.x86_64.rpm;
-          curl -L -k -o rpms/pbspro-server-18.1.4-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//pbspro-server-18.1.4-0.x86_64.rpm;
       
       - name: Create Release
         id: create_release
@@ -60,140 +44,140 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/cyclecloud-pbspro-pkg-${{ steps.get_version.outputs.version }}.tar.gz
+          asset_path: blobs/cyclecloud-pbspro-pkg-${{ steps.get_version.outputs.version }}.tar.gz
           asset_name: cyclecloud-pbspro-pkg-${{ steps.get_version.outputs.version }}.tar.gz
           asset_content_type: application/gzip
 
       
       - name: Upload cyclecloud_api-8.3.1-py2.py3-none-any.whl;
+        id: upload-0
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: blobs/cyclecloud_api-8.3.1-py2.py3-none-any.whl
+          asset_name: cyclecloud_api-8.3.1-py2.py3-none-any.whl;
+          asset_content_type: application/octet-stream
+
+      - name: Upload hwloc-libs-1.11.9-3.el8.x86_64.rpm;
         id: upload-1
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: rpms/cyclecloud_api-8.3.1-py2.py3-none-any.whl
-          asset_name: cyclecloud_api-8.3.1-py2.py3-none-any.whl;
+          asset_path: blobs/hwloc-libs-1.11.9-3.el8.x86_64.rpm
+          asset_name: hwloc-libs-1.11.9-3.el8.x86_64.rpm;
           asset_content_type: application/octet-stream
 
-      - name: Upload hwloc-libs-1.11.9-3.el8.x86_64.rpm;
+      - name: Upload openpbs-client-20.0.1-0.x86_64.rpm;
         id: upload-2
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: rpms/hwloc-libs-1.11.9-3.el8.x86_64.rpm
-          asset_name: hwloc-libs-1.11.9-3.el8.x86_64.rpm;
+          asset_path: blobs/openpbs-client-20.0.1-0.x86_64.rpm
+          asset_name: openpbs-client-20.0.1-0.x86_64.rpm;
           asset_content_type: application/octet-stream
 
-      - name: Upload openpbs-client-20.0.1-0.x86_64.rpm;
+      - name: Upload openpbs-client-22.05.11-0.x86_64.rpm;
         id: upload-3
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: rpms/openpbs-client-20.0.1-0.x86_64.rpm
-          asset_name: openpbs-client-20.0.1-0.x86_64.rpm;
+          asset_path: blobs/openpbs-client-22.05.11-0.x86_64.rpm
+          asset_name: openpbs-client-22.05.11-0.x86_64.rpm;
           asset_content_type: application/octet-stream
 
-      - name: Upload openpbs-client-22.05.11-0.x86_64.rpm;
+      - name: Upload openpbs-execution-20.0.1-0.x86_64.rpm;
         id: upload-4
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: rpms/openpbs-client-22.05.11-0.x86_64.rpm
-          asset_name: openpbs-client-22.05.11-0.x86_64.rpm;
+          asset_path: blobs/openpbs-execution-20.0.1-0.x86_64.rpm
+          asset_name: openpbs-execution-20.0.1-0.x86_64.rpm;
           asset_content_type: application/octet-stream
 
-      - name: Upload openpbs-execution-20.0.1-0.x86_64.rpm;
+      - name: Upload openpbs-execution-22.05.11-0.x86_64.rpm;
         id: upload-5
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: rpms/openpbs-execution-20.0.1-0.x86_64.rpm
-          asset_name: openpbs-execution-20.0.1-0.x86_64.rpm;
+          asset_path: blobs/openpbs-execution-22.05.11-0.x86_64.rpm
+          asset_name: openpbs-execution-22.05.11-0.x86_64.rpm;
           asset_content_type: application/octet-stream
 
-      - name: Upload openpbs-execution-22.05.11-0.x86_64.rpm;
+      - name: Upload openpbs-server-20.0.1-0.x86_64.rpm;
         id: upload-6
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: rpms/openpbs-execution-22.05.11-0.x86_64.rpm
-          asset_name: openpbs-execution-22.05.11-0.x86_64.rpm;
+          asset_path: blobs/openpbs-server-20.0.1-0.x86_64.rpm
+          asset_name: openpbs-server-20.0.1-0.x86_64.rpm;
           asset_content_type: application/octet-stream
 
-      - name: Upload openpbs-server-20.0.1-0.x86_64.rpm;
+      - name: Upload openpbs-server-22.05.11-0.x86_64.rpm;
         id: upload-7
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: rpms/openpbs-server-20.0.1-0.x86_64.rpm
-          asset_name: openpbs-server-20.0.1-0.x86_64.rpm;
+          asset_path: blobs/openpbs-server-22.05.11-0.x86_64.rpm
+          asset_name: openpbs-server-22.05.11-0.x86_64.rpm;
           asset_content_type: application/octet-stream
 
-      - name: Upload openpbs-server-22.05.11-0.x86_64.rpm;
+      - name: Upload pbspro-client-18.1.4-0.x86_64.rpm;
         id: upload-8
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: rpms/openpbs-server-22.05.11-0.x86_64.rpm
-          asset_name: openpbs-server-22.05.11-0.x86_64.rpm;
+          asset_path: blobs/pbspro-client-18.1.4-0.x86_64.rpm
+          asset_name: pbspro-client-18.1.4-0.x86_64.rpm;
           asset_content_type: application/octet-stream
 
-      - name: Upload pbspro-client-18.1.4-0.x86_64.rpm;
+      - name: Upload pbspro-debuginfo-18.1.4-0.x86_64.rpm;
         id: upload-9
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: rpms/pbspro-client-18.1.4-0.x86_64.rpm
-          asset_name: pbspro-client-18.1.4-0.x86_64.rpm;
+          asset_path: blobs/pbspro-debuginfo-18.1.4-0.x86_64.rpm
+          asset_name: pbspro-debuginfo-18.1.4-0.x86_64.rpm;
           asset_content_type: application/octet-stream
 
-      - name: Upload pbspro-debuginfo-18.1.4-0.x86_64.rpm;
+      - name: Upload pbspro-execution-18.1.4-0.x86_64.rpm;
         id: upload-10
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: rpms/pbspro-debuginfo-18.1.4-0.x86_64.rpm
-          asset_name: pbspro-debuginfo-18.1.4-0.x86_64.rpm;
+          asset_path: blobs/pbspro-execution-18.1.4-0.x86_64.rpm
+          asset_name: pbspro-execution-18.1.4-0.x86_64.rpm;
           asset_content_type: application/octet-stream
 
-      - name: Upload pbspro-execution-18.1.4-0.x86_64.rpm;
+      - name: Upload pbspro-server-18.1.4-0.x86_64.rpm;
         id: upload-11
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: rpms/pbspro-execution-18.1.4-0.x86_64.rpm
-          asset_name: pbspro-execution-18.1.4-0.x86_64.rpm;
-          asset_content_type: application/octet-stream
-
-      - name: Upload pbspro-server-18.1.4-0.x86_64.rpm;
-        id: upload-12
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: rpms/pbspro-server-18.1.4-0.x86_64.rpm
+          asset_path: blobs/pbspro-server-18.1.4-0.x86_64.rpm
           asset_name: pbspro-server-18.1.4-0.x86_64.rpm;
           asset_content_type: application/octet-stream
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,7 @@ jobs:
         run:
           sudo apt update || apt update;
           sudo apt-get install -y python3 python3-pip || apt-get install -y python3 python3-pip;
-          pip3 install virtualenv;
-          python3 -m virtualenv $GITHUB_WORKSPACE/.venv/;
-          source $GITHUB_WORKSPACE/.venv/bin/activate && python package.py;
+          ./build.sh
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ build
 blobs/**
 dist/**
 .env
+libs/**
+venv/**

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,31 +3,23 @@
 Test CycleCloud OpenPBS changes by creating new OpenPBS clusters.
 
 ## Prerequisites
-Install the [Azure CycleCloud CLI](https://learn.microsoft.com/azure/cyclecloud/how-to/install-cyclecloud-cli?view=cyclecloud-8) and confirm it is connected to your CycleCloud instance by running the following command. The expected ouput is `CycleCloud is configured properly`.
+Install the [Azure CycleCloud CLI](https://learn.microsoft.com/azure/cyclecloud/how-to/install-cyclecloud-cli?view=cyclecloud-8) and confirm it is connected to your CycleCloud instance by running the following command. The expected output is `CycleCloud is configured properly`.
 ```bash
 cyclecloud initialize
 ```
 Install a container runtime like [Docker](https://www.docker.com/) or [Podman](https://podman.io/) on your system.  
-These instructions are for [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
 
 ## 1. Upload to Your Storage Locker
 1. Clone the `cyclecloud-pbspro` repository and make your desired changes.
-```bash
-git clone https://github.com/Azure/cyclecloud-pbspro.git
-```
-2. Go to the root of the `cyclecloud-pbspro` repository.
-```bash
-cd cyclecloud-pbspro
-```
-3. Run the following command to prepare [project blobs](https://learn.microsoft.com/azure/cyclecloud/how-to/storage-blobs?view=cyclecloud-8_).
+2. From the root of the repository, run the following command to prepare [project blobs](https://learn.microsoft.com/azure/cyclecloud/how-to/storage-blobs?view=cyclecloud-8_) and generate `release.yml`.
 ```bash
 ./build.sh
 ```
-4. Run the following command then copy the name of the locker you would like to upload project blobs to.
+3. Run the following command then copy the name of the locker you would like to upload project blobs to.
 ```bash
 cyclecloud locker list
 ```
-5. Run the following command to upload project blobs to your locker.
+4. Run the following command to upload project blobs to your locker.
 ```bash
 cyclecloud project upload "LOCKER_NAME"
 ```
@@ -37,8 +29,9 @@ Replace `LOCKER_NAME` with the name of your locker.
 1. Update the openpbs template to point to your changes by running the following commands.
 ```bash
 cp templates/openpbs.txt templates/openpbs-test.txt
-sed -i -e 's/\(\[*cluster-init[^]]*\)\]/\1:2.0.24]/' -e 's/cyclecloud\/pbspro/pbspro/g' templates/openpbs-test.txt
+sed -i -e 's/\(\[*cluster-init[^]]*\)\]/\1:RELEASE_VERSION]/' -e 's/cyclecloud\/pbspro/pbspro/g' templates/openpbs-test.txt
 ``` 
+Replace `RELEASE_VERSION` with the cyclecloud-pbspro release version (ex: `2.0.24`)
  
 2.  Import the template by running the following command.
 ```bash

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,71 +1,40 @@
 # Test Azure CycleCloud OpenPBS Project Changes
 
-Test CycleCloud OpenPBS changes by creating new OpenPBS cluster.
+Test CycleCloud OpenPBS changes by creating new OpenPBS clusters.
 
 ## Prerequisites
-Install the [Azure CycleCloud CLI](https://learn.microsoft.com/azure/cyclecloud/how-to/install-cyclecloud-cli?view=cyclecloud-8) and a container runtime like [Docker](https://www.docker.com/) or [Podman](https://podman.io/) on your system.  
-These instructions are for [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) and assume you have already cloned the `cyclecloud-pbspro` repository and made your desired changes.
-
-## 1. Prepare Files to Upload to Your Storage Locker
-1. Navigate to the root of the `cyclecloud-pbspro` repository.
-2. Run the following command.
-```bash
-python package.py
-```
-3. Navigate to `cyclecloud-pbspro/dist` and `cyclecloud-pbspro-pkg-2.0.24.tar.gz` should be present. Copy the file to `cyclecloud-pbspro/blobs` by running the following command.
-```bash
-sudo cp cyclecloud-pbspro-pkg-2.0.24.tar.gz ~/<path_to_repo>/cyclecloud-pbspro/blobs
-```
-Replace `<path_to_repo>` with the path to the cloned `cyclecloud-pbspro` repository.
-
-4. Navigate to `cyclecloud-pbspro/blobs` and create a directory named `rpms`.
-```bash
-sudo mkdir rpms
-```
-5. Run the following command from `cyclecloud-pbspro/blobs` to get required .rpm files.
-```bash
-sudo curl -L -k -o rpms/cyclecloud_api-8.3.1-py2.py3-none-any.whl https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//cyclecloud_api-8.3.1-py2.py3-none-any.whl;
-sudo curl -L -k -o rpms/hwloc-libs-1.11.9-3.el8.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//hwloc-libs-1.11.9-3.el8.x86_64.rpm;
-sudo curl -L -k -o rpms/openpbs-client-20.0.1-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-client-20.0.1-0.x86_64.rpm;
-sudo curl -L -k -o rpms/openpbs-client-22.05.11-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-client-22.05.11-0.x86_64.rpm;
-sudo curl -L -k -o rpms/openpbs-execution-20.0.1-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-execution-20.0.1-0.x86_64.rpm;
-sudo curl -L -k -o rpms/openpbs-execution-22.05.11-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-execution-22.05.11-0.x86_64.rpm;
-sudo curl -L -k -o rpms/openpbs-server-20.0.1-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-server-20.0.1-0.x86_64.rpm;
-sudo curl -L -k -o rpms/openpbs-server-22.05.11-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-server-22.05.11-0.x86_64.rpm;
-sudo curl -L -k -o rpms/pbspro-client-18.1.4-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//pbspro-client-18.1.4-0.x86_64.rpm;
-sudo curl -L -k -o rpms/pbspro-debuginfo-18.1.4-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//pbspro-debuginfo-18.1.4-0.x86_64.rpm;
-sudo curl -L -k -o rpms/pbspro-execution-18.1.4-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//pbspro-execution-18.1.4-0.x86_64.rpm;
-sudo curl -L -k -o rpms/pbspro-server-18.1.4-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//pbspro-server-18.1.4-0.x86_64.rpm;
-```
-6. Move the new .rpm files to the blobs directory.
-```bash 
-sudo mv ~/<path_to_repo>/cyclecloud-pbspro/blobs/rpms/* ~/<path_to_repo>/cyclecloud-pbspro/blobs
-```
-7. You should now see the following 13 files under `cyclecloud-pbspro/blobs`
-```bash
-cyclecloud-pbspro-pkg-2.0.24.tar.gz        openpbs-client-20.0.1-0.x86_64.rpm     openpbs-execution-22.05.11-0.x86_64.rpm  pbspro-client-18.1.4-0.x86_64.rpm     pbspro-server-18.1.4-0.x86_64.rpm
-cyclecloud_api-8.3.1-py2.py3-none-any.whl  openpbs-client-22.05.11-0.x86_64.rpm   openpbs-server-20.0.1-0.x86_64.rpm       pbspro-debuginfo-18.1.4-0.x86_64.rpm
-hwloc-libs-1.11.9-3.el8.x86_64.rpm         openpbs-execution-20.0.1-0.x86_64.rpm  openpbs-server-22.05.11-0.x86_64.rpm     pbspro-execution-18.1.4-0.x86_64.rpm
-```
-
-## 2. Uploading to Your Storage Locker
-1. Confirm that the Azure CycleCloud CLI is installed and connected to your CycleCloud instance by running the following command. The expected output is `CycleCloud is configured properly`.
+Install the [Azure CycleCloud CLI](https://learn.microsoft.com/azure/cyclecloud/how-to/install-cyclecloud-cli?view=cyclecloud-8) and confirm it is connected to your CycleCloud instance by running the following command. The expected ouput is `CycleCloud is configured properly`.
 ```bash
 cyclecloud initialize
 ```
-2. If you have yet to do so, set up a storage account for your CycleCloud instance to access.
-3. Run the following command and confirm the presence of the storage account you would like to upload a blob to.
+Install a container runtime like [Docker](https://www.docker.com/) or [Podman](https://podman.io/) on your system.  
+These instructions are for [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
+
+## 1. Upload to Your Storage Locker
+1. Clone the `cyclecloud-pbspro` repository and make your desired changes.
+```bash
+git clone https://github.com/Azure/cyclecloud-pbspro.git
+```
+2. Go to the root of the `cyclecloud-pbspro` repository.
+```bash
+cd cyclecloud-pbspro
+```
+3. Run the following command to prepare [project blobs](https://learn.microsoft.com/azure/cyclecloud/how-to/storage-blobs?view=cyclecloud-8_).
+```bash
+python package.py
+```
+4. Run the following command then copy the name of the locker you would like to upload project blobs to.
 ```bash
 cyclecloud locker list
 ```
-4. From the root of the `cyclecloud-pbspro` repository, run the following command to upload a blob to your locker.
+5. Run the following command to upload project blobs to your locker.
 ```bash
-cyclecloud project upload "<locker name>"
+cyclecloud project upload "LOCKER_NAME"
 ```
-Replace `<locker name>` with the name of your locker.
+Replace `LOCKER_NAME` with the name of your locker.
 
-## 3. Editing Your Cluster Template and Deploying a Cluster
-1. Update your openpbs template to point to your changes by running the following commands from the root of the `cyclecloud-pbspro` repository.
+## 2. Edit Your Cluster Template and Deploy a Cluster
+1. Update the openpbs template to point to your changes by running the following commands.
 ```bash
 cp templates/openpbs.txt templates/openpbs-test.txt
 sed -i -e 's/\(\[*cluster-init[^]]*\)\]/\1:2.0.24]/' -e 's/cyclecloud\/pbspro/pbspro/g' templates/openpbs-test.txt
@@ -73,8 +42,8 @@ sed -i -e 's/\(\[*cluster-init[^]]*\)\]/\1:2.0.24]/' -e 's/cyclecloud\/pbspro/pb
  
 2.  Import the template by running the following command.
 ```bash
-cyclecloud import_template -f templates/openpbs-test.txt -c openpbs <openpbs-preview>
+cyclecloud import_template -f templates/openpbs-test.txt -c openpbs OPENPBS_PREVIEW
 ```
-Replace `<openpbs-preview>` with your desired name for the new cluster
+Replace `OPENPBS_PREVIEW` with the desired name for your new cluster type.
 
-3. Using the CycleCloud UI, create a new cluster. `<openpbs-preview>` should appear as one of the scheduler options.
+3. Using the CycleCloud UI, create a new cluster and select `OPENPBS_PREVIEW` as the scheduler.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,80 @@
+# Test Azure CycleCloud OpenPBS Project Changes
+
+Test CycleCloud OpenPBS changes by creating new OpenPBS cluster.
+
+## Prerequisites
+Install the [Azure CycleCloud CLI](https://learn.microsoft.com/azure/cyclecloud/how-to/install-cyclecloud-cli?view=cyclecloud-8) and a container runtime like [Docker](https://www.docker.com/) or [Podman](https://podman.io/) on your system.  
+These instructions are for [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) and assume you have already cloned the `cyclecloud-pbspro` repository and made your desired changes.
+
+## 1. Prepare Files to Upload to Your Storage Locker
+1. Navigate to the root of the `cyclecloud-pbspro` repository.
+2. Run the following command.
+```bash
+python package.py
+```
+3. Navigate to `cyclecloud-pbspro/dist` and `cyclecloud-pbspro-pkg-2.0.24.tar.gz` should be present. Copy the file to `cyclecloud-pbspro/blobs` by running the following command.
+```bash
+sudo cp cyclecloud-pbspro-pkg-2.0.24.tar.gz ~/<path_to_repo>/cyclecloud-pbspro/blobs
+```
+Replace `<path_to_repo>` with the path to the cloned `cyclecloud-pbspro` repository.
+
+4. Navigate to `cyclecloud-pbspro/blobs` and create a directory named `rpms`.
+```bash
+sudo mkdir rpms
+```
+5. Run the following command from `cyclecloud-pbspro/blobs` to get required .rpm files.
+```bash
+sudo curl -L -k -o rpms/cyclecloud_api-8.3.1-py2.py3-none-any.whl https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//cyclecloud_api-8.3.1-py2.py3-none-any.whl;
+sudo curl -L -k -o rpms/hwloc-libs-1.11.9-3.el8.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//hwloc-libs-1.11.9-3.el8.x86_64.rpm;
+sudo curl -L -k -o rpms/openpbs-client-20.0.1-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-client-20.0.1-0.x86_64.rpm;
+sudo curl -L -k -o rpms/openpbs-client-22.05.11-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-client-22.05.11-0.x86_64.rpm;
+sudo curl -L -k -o rpms/openpbs-execution-20.0.1-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-execution-20.0.1-0.x86_64.rpm;
+sudo curl -L -k -o rpms/openpbs-execution-22.05.11-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-execution-22.05.11-0.x86_64.rpm;
+sudo curl -L -k -o rpms/openpbs-server-20.0.1-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-server-20.0.1-0.x86_64.rpm;
+sudo curl -L -k -o rpms/openpbs-server-22.05.11-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//openpbs-server-22.05.11-0.x86_64.rpm;
+sudo curl -L -k -o rpms/pbspro-client-18.1.4-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//pbspro-client-18.1.4-0.x86_64.rpm;
+sudo curl -L -k -o rpms/pbspro-debuginfo-18.1.4-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//pbspro-debuginfo-18.1.4-0.x86_64.rpm;
+sudo curl -L -k -o rpms/pbspro-execution-18.1.4-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//pbspro-execution-18.1.4-0.x86_64.rpm;
+sudo curl -L -k -o rpms/pbspro-server-18.1.4-0.x86_64.rpm https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins//pbspro-server-18.1.4-0.x86_64.rpm;
+```
+6. Move the new .rpm files to the blobs directory.
+```bash 
+sudo mv ~/<path_to_repo>/cyclecloud-pbspro/blobs/rpms/* ~/<path_to_repo>/cyclecloud-pbspro/blobs
+```
+7. You should now see the following 13 files under `cyclecloud-pbspro/blobs`
+```bash
+cyclecloud-pbspro-pkg-2.0.24.tar.gz        openpbs-client-20.0.1-0.x86_64.rpm     openpbs-execution-22.05.11-0.x86_64.rpm  pbspro-client-18.1.4-0.x86_64.rpm     pbspro-server-18.1.4-0.x86_64.rpm
+cyclecloud_api-8.3.1-py2.py3-none-any.whl  openpbs-client-22.05.11-0.x86_64.rpm   openpbs-server-20.0.1-0.x86_64.rpm       pbspro-debuginfo-18.1.4-0.x86_64.rpm
+hwloc-libs-1.11.9-3.el8.x86_64.rpm         openpbs-execution-20.0.1-0.x86_64.rpm  openpbs-server-22.05.11-0.x86_64.rpm     pbspro-execution-18.1.4-0.x86_64.rpm
+```
+
+## 2. Uploading to Your Storage Locker
+1. Confirm that the Azure CycleCloud CLI is installed and connected to your CycleCloud instance by running the following command. The expected output is `CycleCloud is configured properly`.
+```bash
+cyclecloud initialize
+```
+2. If you have yet to do so, set up a storage account for your CycleCloud instance to access.
+3. Run the following command and confirm the presence of the storage account you would like to upload a blob to.
+```bash
+cyclecloud locker list
+```
+4. From the root of the `cyclecloud-pbspro` repository, run the following command to upload a blob to your locker.
+```bash
+cyclecloud project upload "<locker name>"
+```
+Replace `<locker name>` with the name of your locker.
+
+## 3. Editing Your Cluster Template and Deploying a Cluster
+1. Update your openpbs template to point to your changes by running the following commands from the root of the `cyclecloud-pbspro` repository.
+```bash
+cp templates/openpbs.txt templates/openpbs-test.txt
+sed -i -e 's/\(\[*cluster-init[^]]*\)\]/\1:2.0.24]/' -e 's/cyclecloud\/pbspro/pbspro/g' templates/openpbs-test.txt
+``` 
+ 
+2.  Import the template by running the following command.
+```bash
+cyclecloud import_template -f templates/openpbs-test.txt -c openpbs <openpbs-preview>
+```
+Replace `<openpbs-preview>` with your desired name for the new cluster
+
+3. Using the CycleCloud UI, create a new cluster. `<openpbs-preview>` should appear as one of the scheduler options.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -21,7 +21,7 @@ cd cyclecloud-pbspro
 ```
 3. Run the following command to prepare [project blobs](https://learn.microsoft.com/azure/cyclecloud/how-to/storage-blobs?view=cyclecloud-8_).
 ```bash
-python package.py
+./build.sh
 ```
 4. Run the following command then copy the name of the locker you would like to upload project blobs to.
 ```bash

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# create a new venv if it does not exist, or is older than 7 days
+if [ ! $(find . -path ./venv/created -mtime -7) ]; then
+    rm -rf venv
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install setuptools
+    touch venv/created
+else
+    source venv/bin/activate
+fi
+
+python package.py

--- a/build.sh
+++ b/build.sh
@@ -11,4 +11,5 @@ else
     source venv/bin/activate
 fi
 
-python package.py
+python package.py 
+python generate_release_yaml.py > .github/workflows/release.yml

--- a/build.sh
+++ b/build.sh
@@ -12,4 +12,8 @@ else
 fi
 
 python package.py 
-python generate_release_yaml.py > .github/workflows/release.yml
+
+if [[ -z "$GITHUB_REF" ]]; then
+    echo "Generating release.yml..."
+    python generate_release_yaml.py > .github/workflows/release.yml
+fi

--- a/generate_release_yaml.py
+++ b/generate_release_yaml.py
@@ -59,7 +59,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/cyclecloud-pbspro-pkg-${{ steps.get_version.outputs.version }}.tar.gz
+          asset_path: blobs/cyclecloud-pbspro-pkg-${{ steps.get_version.outputs.version }}.tar.gz
           asset_name: cyclecloud-pbspro-pkg-${{ steps.get_version.outputs.version }}.tar.gz
           asset_content_type: application/gzip
 

--- a/generate_release_yaml.py
+++ b/generate_release_yaml.py
@@ -22,9 +22,7 @@ jobs:
         run:
           sudo apt update || apt update;
           sudo apt-get install -y python3 python3-pip || apt-get install -y python3 python3-pip;
-          pip3 install virtualenv;
-          python3 -m virtualenv $GITHUB_WORKSPACE/.venv/;
-          source $GITHUB_WORKSPACE/.venv/bin/activate && python package.py;
+          ./build.sh
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}

--- a/generate_release_yaml.py
+++ b/generate_release_yaml.py
@@ -33,7 +33,7 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
@@ -45,7 +45,7 @@ jobs:
         id: upload-release-asset 
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: blobs/cyclecloud-pbspro-pkg-${{ steps.get_version.outputs.version }}.tar.gz
@@ -60,7 +60,7 @@ UPLOAD_TEMPLATE = """
         id: upload-%(index)s
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ACTION_PAT }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: blobs/%(fname)s

--- a/package.py
+++ b/package.py
@@ -3,12 +3,11 @@ import configparser
 import glob
 import os
 import shutil
-import subprocess
 import sys
 import tarfile
 import tempfile
 from argparse import Namespace
-from subprocess import check_call
+from subprocess import check_call, run
 from typing import Dict, List, Optional
 
 SCALELIB_VERSION = "1.0.5"
@@ -59,7 +58,8 @@ def get_cycle_packages(args: Namespace) -> List[str]:
             ret.append(fname)
         else:
             dest = os.path.join("blobs" if pkg_file == cyclecloud_api_file else "libs", pkg_file)
-            check_call(["curl", "-L", "-k", "-s", "-f", "-o", dest, url])
+            check_call(["curl", "-L", "-s", "-f", "-z", dest, "-o", dest, url])
+
             ret.append(pkg_file)
             print("Downloaded", pkg_file, "to", dest)
 
@@ -81,7 +81,7 @@ def download_release_files():
     ]
 
     for url in urls:
-        subprocess.run(["curl", "-L", "-O", url], cwd="blobs", check=True)
+        run(["curl", "-L", "-C", "-", "-s", "-O", url], cwd="blobs", check=True)
 
 def execute() -> None:
     expected_cwd = os.path.abspath(os.path.dirname(__file__))

--- a/package.py
+++ b/package.py
@@ -7,8 +7,9 @@ import sys
 import tarfile
 import tempfile
 from argparse import Namespace
-from subprocess import check_call, run
+from subprocess import check_call
 from typing import Dict, List, Optional
+from util import download_release_files
 
 SCALELIB_VERSION = "1.0.5"
 CYCLECLOUD_API_VERSION = "8.3.1"
@@ -64,24 +65,6 @@ def get_cycle_packages(args: Namespace) -> List[str]:
             print("Downloaded", pkg_file, "to", dest)
 
     return ret
-
-def download_release_files():
-    urls = [
-        'https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins/hwloc-libs-1.11.9-3.el8.x86_64.rpm',
-        'https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins/openpbs-client-20.0.1-0.x86_64.rpm',
-        'https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins/openpbs-client-22.05.11-0.x86_64.rpm',
-        'https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins/openpbs-execution-20.0.1-0.x86_64.rpm',
-        'https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins/openpbs-execution-22.05.11-0.x86_64.rpm',
-        'https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins/openpbs-server-20.0.1-0.x86_64.rpm',
-        'https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins/openpbs-server-22.05.11-0.x86_64.rpm',
-        'https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins/pbspro-client-18.1.4-0.x86_64.rpm',
-        'https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins/pbspro-debuginfo-18.1.4-0.x86_64.rpm',
-        'https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins/pbspro-execution-18.1.4-0.x86_64.rpm',
-        'https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins/pbspro-server-18.1.4-0.x86_64.rpm'
-    ]
-
-    for url in urls:
-        run(["curl", "-L", "-C", "-", "-s", "-O", url], cwd="blobs", check=True)
 
 def execute() -> None:
     expected_cwd = os.path.abspath(os.path.dirname(__file__))

--- a/util.py
+++ b/util.py
@@ -1,0 +1,25 @@
+from configparser import ConfigParser
+import os
+from subprocess import run
+
+RELEASE_URL = (
+        "https://github.com/Azure/cyclecloud-pbspro/releases/download/2023-03-29-bins"
+        )
+RELEASE_URL = RELEASE_URL.rstrip("/") + "/"
+
+def download_release_files():
+    blobs = get_blobs()
+    for _, fname in enumerate(blobs):
+        if fname == "cyclecloud_api":
+                continue
+    
+        url = os.path.join(RELEASE_URL, fname)
+        run(["curl", "-L", "-C", "-", "-s", "-O", url], cwd="blobs", check=True)
+
+def get_blobs():     
+     parser = ConfigParser()
+     parser.read("project.ini")
+     blobs = [x.strip() for x in parser.get("blobs", "Files").split(",") if "cyclecloud-pbspro-pkg" not in x]
+
+     return blobs
+


### PR DESCRIPTION
- Edited package.py to put project blobs and cyclecloud-pbspro-pkg-2.0.24.tar.gz directly into the blobs directory. Files are only downloaded if they are not already present.
- Added build.sh which sets up a venv, runs package.py, and generates release.yml.
- Added BUILDING.md which describes how to test changes to a pbs cluster.