### PR TITLE
ensure shared consumable resources are treated as int/float for their…

### DIFF
--- a/package.py
+++ b/package.py
@@ -11,7 +11,7 @@ from subprocess import check_call
 from typing import Dict, List, Optional
 from util import download_release_files
 
-SCALELIB_VERSION = "1.0.5"
+SCALELIB_VERSION = "1.0.11"
 CYCLECLOUD_API_VERSION = "8.3.1"
 
 

--- a/pbspro/src/pbspro/pbsqueue.py
+++ b/pbspro/src/pbspro/pbsqueue.py
@@ -126,9 +126,13 @@ class PBSProQueue:
 
             if shared_resource_list[0].is_consumable:
 
+                # A queue/server (non-host) consumable is consumed once for the
+                # whole job, not once per node. decrement_once ensures the shared
+                # value is decremented a single time even when the job spans
+                # multiple nodes (which each invoke do_decrement).
                 ret.append(
                     conslib.SharedConsumableConstraint(
-                        shared_resource_list, rvalue / nodect
+                        shared_resource_list, rvalue, decrement_once=True
                     )
                 )
             else:

--- a/pbspro/test/pbspro_test/queue_test.py
+++ b/pbspro/test/pbspro_test/queue_test.py
@@ -100,6 +100,59 @@ def test_non_schedulable_shared_resources() -> None:
     assert test_queue.resource_state.shared_resources["qres"][0].current_value == 3
 
 
+def test_shared_resource_decremented_once_across_nodes() -> None:
+    # A queue-level (flag=q) consumable is consumed once for the whole job,
+    # not once per node. A multi-node job (nodect > 1) reuses the same
+    # constraint instance for each node it spans, so the shared value must
+    # only be decremented a single time - and the request must stay integral.
+    test_queue = PBSProQueue(
+        name="testq",
+        queue_type="execution",
+        total_jobs=0,
+        state_count={},
+        resources_default={},
+        default_chunk={},
+        node_group_enable=True,
+        node_group_key="group_id",
+        resource_state=ResourceState(
+            resources_available={},
+            resources_assigned={},
+            shared_resources={
+                "qres": [
+                    SharedConsumableResource(
+                        resource_name="qres",
+                        source="queue",
+                        current_value=10,
+                        initial_value=10,
+                    )
+                ]
+            },
+        ),
+        resource_definitions={
+            "qres": PBSProResourceDefinition("qres", LongType(), flag="q")
+        },
+        enabled=True,
+        started=True,
+    )
+
+    # Job requests qres=1 and spans 3 nodes.
+    non_host_cons = test_queue.get_non_host_constraints({"qres": 1}, 3)
+    assert len(non_host_cons) == 1
+
+    qres = test_queue.resource_state.shared_resources["qres"][0]
+
+    # Simulate the autoscaler decrementing once per node the job spans.
+    for i in range(3):
+        snode = SchedulerNode("localhost-{}".format(i), {})
+        assert snode.decrement(non_host_cons)
+
+    # Exactly one unit consumed total (not 3), and the value remains an int.
+    assert qres.current_value == 9, "Expected 9, got {!r}".format(qres.current_value)
+    assert isinstance(
+        qres.current_value, int
+    ), "Expected int, got {}".format(type(qres.current_value).__name__)
+
+
 @pytest.mark.skip
 def test_disabled_queues() -> None:
     assert False


### PR DESCRIPTION
… lifespan

type=long flag=q resources would sometimes cause floating point rounding errors with enough multi-node jobs. Uses 1.0.11 of scalelib which fixes this issue by allowing the decrement_once flag on the constraint.